### PR TITLE
Replace instances of heroku URL with new Render URL

### DIFF
--- a/cypress/integration/Header_spec.js
+++ b/cypress/integration/Header_spec.js
@@ -1,6 +1,6 @@
 describe("Header", () => {
   beforeEach(() => {
-    cy.intercept('https://brewedtoserve.herokuapp.com/brews', {
+    cy.intercept('https://brewed-to-serve.onrender.com/brews', {
         fixture: 'brews'
       })
       .visit('https://blendswithbenefits.netlify.app/')

--- a/cypress/support/commands.js
+++ b/cypress/support/commands.js
@@ -1,5 +1,5 @@
 Cypress.Commands.add('addToCart',() => {
-  cy.intercept('https://brewedtoserve.herokuapp.com/brews', {
+  cy.intercept('https://brewed-to-serve.onrender.com/brews', {
         fixture: 'brews'
       })
       .visit('https://blendswithbenefits.netlify.app/shop/')
@@ -17,7 +17,7 @@ Cypress.Commands.add('addToCart',() => {
 })
 
 Cypress.Commands.add('clearCart', () => {
-  cy.intercept('https://brewedtoserve.herokuapp.com/brews', {
+  cy.intercept('https://brewed-to-serve.onrender.com/brews', {
     fixture: 'brews'
   })
   .visit('https://blendswithbenefits.netlify.app/cart/')
@@ -37,7 +37,7 @@ Cypress.Commands.add('clearCart', () => {
 
 Cypress.Commands.add('placeOrder', () => {
   cy.addToCart()
-  cy.intercept('https://brewedtoserve.herokuapp.com/brews', {
+  cy.intercept('https://brewed-to-serve.onrender.com/brews', {
     fixture: 'brews'
   })
   .visit('https://blendswithbenefits.netlify.app/cart/')

--- a/src/redux/brewSlice.js
+++ b/src/redux/brewSlice.js
@@ -5,7 +5,7 @@ export const getAllBrewsAsync = createAsyncThunk(
   'brews/allBrews/getBrewsAsync',
   async () => {
     try {
-      const resp = await fetch("https://brewedtoserve.herokuapp.com/brews")
+      const resp = await fetch("https://brewed-to-serve.onrender.com/brews")
       if (resp.ok) {
         const brews = await resp.json()
         return brews


### PR DESCRIPTION
### What'd ya do to the code, pal?
Tossed Heroku in the trash, we're using Render now. Replaced all instances of previous Heroku URL with new Render URL. App is working with new API host service.

### Did this break anything? 
- [x] No
- [ ] Yes

### Type of change
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] Refactor(DRY-ing up/ reorganizing code, etc.)
- [ ] Super small fix (Corrected a typo, removed a comment, etc.)
       Skip all the other stuff and briefly explain the fix. 

### Checklist:
- [x] If this code needs to be tested, all tests are passing
- [x] The code runs locally
- [x] There are comments where clarification/ organization is needed
- [x] The code is DRY. If it's not, I tried my best
- [x] I reviewed my code before pushing